### PR TITLE
Add support for Home Assistant scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Home Assistant integration for NEEO.
  - light
  - switch
  - scene
+ - script
 
 ## Setup
 

--- a/controller.js
+++ b/controller.js
@@ -10,6 +10,7 @@ const MACRO_POWER_ON = 'POWER ON';
 const MACRO_POWER_OFF = 'POWER OFF';
 const MACRO_POWER_TOGGLE = 'POWER_TOGGLE';
 const MACRO_ACTIVATE_SCENE = 'ACTIVATE_SCENE';
+const MACRO_ACTIVATE_SCRIPT = 'ACTIVATE_SCRIPT';
 
 let haService;
 let updateCallbackReference, markDeviceOn, markDeviceOff;
@@ -61,6 +62,9 @@ module.exports.onButtonPressed = (action, deviceId) => {
     case MACRO_ACTIVATE_SCENE:
       debug(`Activate scene ${deviceId}`);
       return activateScene(deviceId);
+    case MACRO_ACTIVATE_SCRIPT:
+        debug(`Activate script ${deviceId}`);
+        return activateScript(deviceId);
     default:
       debug(`Unsupported button: ${action} for ${deviceId}`);
       return Promise.resolve(false);
@@ -91,6 +95,15 @@ function toggleDevice(deviceId) {
  */
 function activateScene(deviceId) {
   return haService.callService(deviceId, 'scene', 'turn_on');
+}
+
+/**
+ * Activate script
+ *
+ * @param {*} deviceId
+ */
+function activateScript(deviceId) {
+    return haService.callService(deviceId, 'script', 'turn_on');
 }
 
 /**
@@ -154,6 +167,14 @@ module.exports.discoverSwitches = function () {
 module.exports.discoverScenes = function () {
   console.log("discover call - scene");
   return discover('scene');
+};
+
+/**
+ * Run a discovery of scripts
+ */
+module.exports.discoverScripts = function () {
+    console.log("discover call - script");
+    return discover('script');
 };
 
 /**

--- a/haservice.js
+++ b/haservice.js
@@ -16,7 +16,7 @@ require('dotenv').load();
  *      light
  *      light|scene
  */
-const SUPPORTED_ENTITY_TYPES = 'light|switch|scene';
+const SUPPORTED_ENTITY_TYPES = 'light|switch|scene|script';
 
 /**
  * Home Assistant Service

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const powerSwitch = {
 
 const POWER_TOGGLE_BUTTON = { name: 'POWER_TOGGLE', label: 'Power Toggle' };
 const ACTIVATE_SCENE_BUTTON = { name: 'ACTIVATE_SCENE', label: 'Activate Scene'};
+const ACTIVATE_SCRIPT_BUTTON = { name: 'ACTIVATE_SCRIPT', label: 'Activate Script'};
 
 const haLightDevice = neeoapi.buildDevice('Light')
   .setManufacturer('Home Assistant')
@@ -58,13 +59,26 @@ const haLightDevice = neeoapi.buildDevice('Light')
   }, controller.discoverScenes)
   .registerInitialiseFunction(controller.initialise);
 
+  const haScriptDevice = neeoapi.buildDevice('Script')
+  .setManufacturer('Home Assistant')
+  .addAdditionalSearchToken('ha')
+  .addAdditionalSearchToken('dev')
+  .setType('ACCESSOIRE')
+  .addButton(ACTIVATE_SCRIPT_BUTTON)
+  .addButtonHandler(controller.onButtonPressed)
+  .enableDiscovery({
+      headerText: 'Discover Home Assistant Scripts',
+      description: 'Select the script to add on the next screen.'
+  }, controller.discoverScripts)
+  .registerInitialiseFunction(controller.initialise);
+
 function startSdkExample(brain) {
   console.log('- Start server');
   neeoapi.startServer({
     brain,
     port: 6336,
     name: 'homeassistant',
-    devices: [haLightDevice, haSwitchDevice, haSceneDevice]
+    devices: [haLightDevice, haSwitchDevice, haSceneDevice, haScriptDevice]
   })
     .then(() => {
       console.log('# READY! use the NEEO app to search for "Home Assistant".');


### PR DESCRIPTION
Scripts are very much like scenes in that they can be activated with a single click. Scripts come in handy for fire and forget type operations, such as turning on a light that turns itself off after a some amount of time.